### PR TITLE
NARE is now visualized as an n-tree, respecting the specification pattern in the DSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ before_install:
 - export COMMIT_SHORT=$(git rev-parse --short HEAD)
 - export ORIGINAL_COMMITTER=$(git log -1 --pretty=format:'%an <%ae>')
 - echo -e "machine github.com\n  login $GH_TOKEN" > ~/.netrc
-- rm "${JAVA_HOME}/lib/security/cacerts"
-- ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
 script:
 - mvn clean install
 - |

--- a/src/main/kotlin/no/nav/nare/core/evaluations/Evaluering.kt
+++ b/src/main/kotlin/no/nav/nare/core/evaluations/Evaluering.kt
@@ -12,14 +12,14 @@ data class Evaluering(
       resultat = resultat og other.resultat,
       begrunnelse = "($begrunnelse OG ${other.begrunnelse})",
       operator = Operator.OG,
-      children = listOf(this, other)
+      children = addChildren(this, other)
    )
 
    infix fun eller(other: Evaluering) = Evaluering(
       resultat = resultat eller other.resultat,
       begrunnelse = "($begrunnelse ELLER ${other.begrunnelse})",
       operator = Operator.ELLER,
-      children = listOf(this, other)
+      children = addChildren(this, other)
    )
 
    fun ikke() = Evaluering(
@@ -28,6 +28,12 @@ data class Evaluering(
       operator = Operator.IKKE,
       children = listOf(this)
    )
+
+   fun addChildren(s: Evaluering, o: Evaluering): List<Evaluering> {
+      if (o.identifikator.isBlank() && o.children.isNotEmpty()) return o.children + s
+      if (s.identifikator.isBlank() && s.children.isNotEmpty()) return s.children + o
+      return listOf(s, o)
+   }
 
    companion object {
       fun ja(begrunnelse: String) = Evaluering(Resultat.Ja, begrunnelse)

--- a/src/main/kotlin/no/nav/nare/core/evaluations/Evaluering.kt
+++ b/src/main/kotlin/no/nav/nare/core/evaluations/Evaluering.kt
@@ -3,8 +3,8 @@ package no.nav.nare.core.evaluations
 data class Evaluering(
    val resultat: Resultat,
    val begrunnelse: String,
-   val beskrivelse: String ="",
-   val identifikator: String ="",
+   val beskrivelse: String = "",
+   val identifikator: String = "",
    val operator: Operator = Operator.INGEN,
    var children: List<Evaluering> = emptyList()) {
 
@@ -12,15 +12,15 @@ data class Evaluering(
       resultat = resultat og other.resultat,
       begrunnelse = "($begrunnelse OG ${other.begrunnelse})",
       operator = Operator.OG,
-      children = addChildren(other)
-   )
+      children = this.specOrChildren() + other.specOrChildren()
+      )
 
    infix fun eller(other: Evaluering) = Evaluering(
       resultat = resultat eller other.resultat,
       begrunnelse = "($begrunnelse ELLER ${other.begrunnelse})",
       operator = Operator.ELLER,
-      children = addChildren(other)
-   )
+      children = this.specOrChildren() + other.specOrChildren()
+      )
 
    fun ikke() = Evaluering(
       resultat = resultat.ikke(),
@@ -29,11 +29,8 @@ data class Evaluering(
       children = listOf(this)
    )
 
-   fun addChildren(other: Evaluering): List<Evaluering> {
-      if (this.identifikator.isBlank() && this.children.isNotEmpty()) return this.children + other
-      if (other.identifikator.isBlank() && other.children.isNotEmpty()) return other.children + this
-      return listOf(this, other)
-   }
+   private fun specOrChildren(): List<Evaluering> =
+      if (identifikator.isBlank() && children.isNotEmpty()) children else listOf(this)
 
    companion object {
       fun ja(begrunnelse: String) = Evaluering(Resultat.Ja, begrunnelse)

--- a/src/main/kotlin/no/nav/nare/core/evaluations/Evaluering.kt
+++ b/src/main/kotlin/no/nav/nare/core/evaluations/Evaluering.kt
@@ -12,14 +12,14 @@ data class Evaluering(
       resultat = resultat og other.resultat,
       begrunnelse = "($begrunnelse OG ${other.begrunnelse})",
       operator = Operator.OG,
-      children = addChildren(this, other)
+      children = addChildren(other)
    )
 
    infix fun eller(other: Evaluering) = Evaluering(
       resultat = resultat eller other.resultat,
       begrunnelse = "($begrunnelse ELLER ${other.begrunnelse})",
       operator = Operator.ELLER,
-      children = addChildren(this, other)
+      children = addChildren(other)
    )
 
    fun ikke() = Evaluering(
@@ -29,10 +29,10 @@ data class Evaluering(
       children = listOf(this)
    )
 
-   fun addChildren(s: Evaluering, o: Evaluering): List<Evaluering> {
-      if (o.identifikator.isBlank() && o.children.isNotEmpty()) return o.children + s
-      if (s.identifikator.isBlank() && s.children.isNotEmpty()) return s.children + o
-      return listOf(s, o)
+   fun addChildren(other: Evaluering): List<Evaluering> {
+      if (this.identifikator.isBlank() && this.children.isNotEmpty()) return this.children + other
+      if (other.identifikator.isBlank() && other.children.isNotEmpty()) return other.children + this
+      return listOf(this, other)
    }
 
    companion object {
@@ -42,7 +42,7 @@ data class Evaluering(
 
       fun kanskje(begrunnelse: String) = Evaluering(Resultat.Kanskje, begrunnelse)
 
-      fun evaluer(identitet: String, beskrivelse: String, eval: Evaluering) = eval.copy(beskrivelse = beskrivelse, identifikator = identitet)
+      fun evaluer(identifikator: String, beskrivelse: String, eval: Evaluering) = eval.copy(identifikator = identifikator, beskrivelse = beskrivelse)
    }
 
 }

--- a/src/main/kotlin/no/nav/nare/core/specifications/Spesifikasjon.kt
+++ b/src/main/kotlin/no/nav/nare/core/specifications/Spesifikasjon.kt
@@ -10,9 +10,6 @@ data class Spesifikasjon<T>(
    val children: List<Spesifikasjon<T>> = emptyList(),
    val implementasjon: T.() -> Evaluering) {
 
-   val treeChildren: List<Spesifikasjon<T>>
-      get() = (children + children.flatMap { if (it.identifikator.isBlank()) it.treeChildren else listOf() })
-
    fun evaluer(t: T): Evaluering {
       return evaluer(
          beskrivelse = beskrivelse,

--- a/src/main/kotlin/no/nav/nare/core/specifications/Spesifikasjon.kt
+++ b/src/main/kotlin/no/nav/nare/core/specifications/Spesifikasjon.kt
@@ -23,7 +23,7 @@ data class Spesifikasjon<T>(
    infix fun og(other: Spesifikasjon<T>): Spesifikasjon<T> {
       return Spesifikasjon(
          beskrivelse = "$beskrivelse OG ${other.beskrivelse}",
-         children = addChildren(other),
+         children = this.specOrChildren() + other.specOrChildren(),
          implementasjon = { evaluer(this) og other.evaluer(this) }
       )
    }
@@ -31,14 +31,14 @@ data class Spesifikasjon<T>(
    infix fun eller(other: Spesifikasjon<T>): Spesifikasjon<T> {
       return Spesifikasjon(
          beskrivelse = "$beskrivelse ELLER ${other.beskrivelse}",
-         children = addChildren(other),
+         children = this.specOrChildren() + other.specOrChildren(),
          implementasjon = { evaluer(this) eller other.evaluer(this) }
       )
    }
 
    fun ikke(): Spesifikasjon<T> {
       return Spesifikasjon(
-         beskrivelse = "IKKE $beskrivelse",
+         beskrivelse = "!$beskrivelse",
          identifikator = "!$identifikator",
          children = listOf(this),
          implementasjon = { evaluer(this).ikke() }
@@ -47,14 +47,10 @@ data class Spesifikasjon<T>(
 
    fun med(identitet: String, beskrivelse: String): Spesifikasjon<T> {
       return this.copy(beskrivelse = beskrivelse, identifikator = identitet)
-
    }
 
-   fun addChildren(other: Spesifikasjon<T>): List<Spesifikasjon<T>> {
-      if (this.identifikator.isBlank() && this.children.isNotEmpty()) return this.children + other
-      if (other.identifikator.isBlank() && other.children.isNotEmpty()) return other.children + this
-      return listOf(this, other)
-   }
+   private fun specOrChildren(): List<Spesifikasjon<T>> =
+      if (identifikator.isBlank() && children.isNotEmpty()) children else listOf(this)
 
 }
 

--- a/src/test/kotlin/no/nav/nare/core/evaluation/SpesifikasjonTest.kt
+++ b/src/test/kotlin/no/nav/nare/core/evaluation/SpesifikasjonTest.kt
@@ -2,6 +2,7 @@
 import no.nav.nare.core.evaluations.Evaluering
 import no.nav.nare.core.evaluations.Resultat
 import no.nav.nare.core.specifications.Spesifikasjon
+import no.nav.nare.core.specifications.ikke
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -42,20 +43,25 @@ class SpesifikasjonTest {
    @Test
    fun ikke() {
       val actual = leaf1.ikke()
-      assertEquals("IKKE leaf1 beskrivelse", actual.beskrivelse)
+      assertEquals("!leaf1 beskrivelse", actual.beskrivelse)
       assertEquals(listOf(leaf1), actual.children)
       assertEquals(Resultat.Nei, actual.implementasjon.invoke("").resultat)
    }
 
 
    @Test
-   fun test_flatten(){
+   fun `removes one intermediate node`(){
       val intermediate = (leaf2 og leaf1)
       val root = (intermediate og leaf3).med(identitet = "root", beskrivelse = "beskrivelse")
-
-      assertEquals(3, root.treeChildren.size)
       assertEquals(3, root.children.size)
-
-
    }
+
+   @Test
+   fun `removes two intermediate nodes`(){
+      val intermediate1 = (leaf2 og leaf1)
+      val intermediate2 = (leaf2 og leaf1)
+      val root = (intermediate1 og intermediate2 ).med(identitet = "root", beskrivelse = "beskrivelse")
+      assertEquals(4, root.children.size)
+   }
+
 }

--- a/src/test/kotlin/no/nav/nare/core/evaluation/SpesifikasjonTest.kt
+++ b/src/test/kotlin/no/nav/nare/core/evaluation/SpesifikasjonTest.kt
@@ -7,40 +7,55 @@ import org.junit.jupiter.api.Test
 
 class SpesifikasjonTest {
 
-   private val left = Spesifikasjon<String>(
-      "left beskrivelse",
-      "left identitet",
+   private val leaf1 = Spesifikasjon<String>(
+      "leaf1 beskrivelse",
+      "leaf1",
       emptyList()) { Evaluering.ja("yepp") }
 
-   private val right = Spesifikasjon<String>(
-      "right beskrivelse",
-      "right identitet",
+   private val leaf2 = Spesifikasjon<String>(
+      "leaf2 beskrivelse",
+      "leaf2",
+      emptyList()) { Evaluering.nei("nope") }
+
+
+   private val leaf3 = Spesifikasjon<String>(
+      "leaf3 beskrivelse",
+      "leaf3",
       emptyList()) { Evaluering.nei("nope") }
 
    @Test
    fun eller() {
-      val actual = left eller right
-      assertEquals("left beskrivelse ELLER right beskrivelse", actual.beskrivelse)
-      assertEquals("left identitet ELLER right identitet", actual.identitet)
-      assertEquals(listOf(left, right), actual.children)
+      val actual = leaf1 eller leaf2
+      assertEquals("leaf1 beskrivelse ELLER leaf2 beskrivelse", actual.beskrivelse)
+      assertEquals(listOf(leaf1, leaf2), actual.children)
       assertEquals(Resultat.Ja, actual.implementasjon.invoke("").resultat)
    }
 
    @Test
    fun og() {
-      val actual = left og right
-      assertEquals("left beskrivelse OG right beskrivelse", actual.beskrivelse)
-      assertEquals("left identitet OG right identitet", actual.identitet)
-      assertEquals(listOf(left, right), actual.children)
+      val actual = leaf1 og leaf2
+      assertEquals("leaf1 beskrivelse OG leaf2 beskrivelse", actual.beskrivelse)
+      assertEquals(listOf(leaf1, leaf2), actual.children)
       assertEquals(Resultat.Nei, actual.implementasjon.invoke("").resultat)
    }
 
    @Test
    fun ikke() {
-      val actual = left.ikke()
-      assertEquals("IKKE left beskrivelse", actual.beskrivelse)
-      assertEquals("IKKE left identitet", actual.identitet)
-      assertEquals(listOf(left), actual.children)
+      val actual = leaf1.ikke()
+      assertEquals("IKKE leaf1 beskrivelse", actual.beskrivelse)
+      assertEquals(listOf(leaf1), actual.children)
       assertEquals(Resultat.Nei, actual.implementasjon.invoke("").resultat)
+   }
+
+
+   @Test
+   fun test_flatten(){
+      val intermediate = (leaf2 og leaf1)
+      val root = (intermediate og leaf3).med(identitet = "root", beskrivelse = "beskrivelse")
+
+      assertEquals(3, root.treeChildren.size)
+      assertEquals(3, root.children.size)
+
+
    }
 }

--- a/src/test/kotlin/no/nav/nare/demo/Demo.kt
+++ b/src/test/kotlin/no/nav/nare/demo/Demo.kt
@@ -21,7 +21,7 @@ fun main() {
    val gson = builder.create()
    port(1339)
    staticFiles.location("/public")
-   get("/api", { _, _ -> Regelsett().mødrekvote.evaluer(søknad) }, { gson.toJson(it) })
+   get("/api", { _, _ -> Regelsett().mødrekvote }, { gson.toJson(it) })
 
 }
 

--- a/src/test/kotlin/no/nav/nare/demo/Demo.kt
+++ b/src/test/kotlin/no/nav/nare/demo/Demo.kt
@@ -21,7 +21,7 @@ fun main() {
    val gson = builder.create()
    port(1339)
    staticFiles.location("/public")
-   get("/api", { _, _ -> Regelsett().mødrekvote }, { gson.toJson(it) })
+   get("/api", { _, _ -> Regelsett().mødrekvote.evaluer(søknad) }, { gson.toJson(it) })
 
 }
 

--- a/src/test/kotlin/no/nav/nare/demo/Modrekvote.kt
+++ b/src/test/kotlin/no/nav/nare/demo/Modrekvote.kt
@@ -20,39 +20,39 @@ class Regelsett {
 
    private val morHarRettTilForeldrepenger = Spesifikasjon<Soknad>(
       beskrivelse = "Har søker med rolle mor rett til foreldrepenger?",
-      identitet = "FK_VK_10.1",
+      identifikator = "FK_VK_10.1",
       implementasjon = { søkerHarPåkrevdRolle(MOR, this) }
    )
 
    private val farHarRettTilForeldrepenger = Spesifikasjon<Soknad>(
       beskrivelse = "Har søker med rolle fae rett til foreldrepenger?",
-      identitet = "FK_VK_10.1",
+      identifikator = "FK_VK_10.1",
       implementasjon = { søkerHarPåkrevdRolle(FAR, this) }
    )
 
    private val gjelderSoknadFødsel = Spesifikasjon<Soknad>(
       beskrivelse = "Soknad gjelder fødsel?",
-      identitet = "FK_VK 10.2",
+      identifikator = "FK_VK 10.2",
       implementasjon = { soknadGjelder(FODSEL, this) }
    )
 
    private val gjelderSoknadAdopsjon = Spesifikasjon<Soknad>(
       beskrivelse = "Soknad gjelder adopsjon?",
-      identitet = "FK_VK 10.23",
+      identifikator = "FK_VK 10.23",
       implementasjon = { soknadGjelder(ADOPSJON, this) }
    )
 
 
    private val harUttaksplanEtterFodsel = Spesifikasjon<Soknad>(
       beskrivelse = "Foreligger det korrekt uttaksplan etter fødsel?",
-      identitet = "FK_VK 10.4/FK_VK 10.5",
+      identifikator = "FK_VK 10.4/FK_VK 10.5",
       implementasjon = { harUttaksplanForModreKvote(FODSEL, this)
       }
    )
 
    private val harUttaksplanEtterAdopsjon = Spesifikasjon<Soknad>(
       beskrivelse = "Foreligger det korrekt uttaksplan etter adopsjon?",
-      identitet = "FK_VK 10.6",
+      identifikator = "FK_VK 10.6",
       implementasjon = { harUttaksplanForModreKvote(ADOPSJON, this) }
    )
 

--- a/src/test/kotlin/no/nav/nare/demo/Modrekvote.kt
+++ b/src/test/kotlin/no/nav/nare/demo/Modrekvote.kt
@@ -87,8 +87,7 @@ fun soknadGjelder(søknadstype: Soknadstype, søknad: Soknad): Evaluering =
       nei("Søknad gjelder ikke fødsel")
 
 fun søkerHarPåkrevdRolle(rolle: Rolle, søknad: Soknad): Evaluering =
-
-   søknad.hentSøkerIRolle(rolle)?.let { person ->
+      søknad.hentSøkerIRolle(rolle)?.let { person ->
       if (person.rettTilFp)
          ja("Søker med rolle $rolle har rett til foreldrepenger")
       else


### PR DESCRIPTION
NARE is now visualised as an n-tree, respecting the specification pattern in the DSL

At its core, the results are still calculated as a binary tree. 
However, the intermediate nodes created by the DSL are now discarded, leaving only those nodes with an identity in the resulting specification and evaluation tree. 
This change simplifies the Influx/Prometheus querying, as well as it makes the visualisation of the evaluation much closer to the specification DSL